### PR TITLE
🔒 Update baseimage to latest version v0.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.20
+FROM phusion/baseimage:0.11
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
I saw that the baseimage could be updated and I just went ahead and did that. I hope it helps. If not I really would appreciate feedback on how to fix this PR. Thanks 😃 

The currently used version (v.9.20) was release over a year ago and the project has had 6 releases since.

To see what changed see this: https://github.com/phusion/baseimage-docker/releases