### PR TITLE
🔒 Update Docker image to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN apt -qqy update                     \
        firefox                          \
        git                              \
        jq                               \
-       python-lazy-object-proxy         \
-       python-lxml                      \
-       python-yaml                      \
-       python-pip                       \
+       python3-lazy-object-proxy         \
+       python3-lxml                      \
+       python3-yaml                      \
+       python3-pip                       \
     && curl -L https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz | tar zxf -  \
     && mv geckodriver /usr/local/bin/   \
     && apt-get remove -y curl           \
@@ -21,7 +21,7 @@ RUN apt -qqy update                     \
 COPY . /kibitzr/
 
 RUN cd /kibitzr                         \
-    && pip install -e .
+    && pip3 install -e .
 
 WORKDIR /root/
 


### PR DESCRIPTION
I also realized that on the baseimage which is based on Ubuntu 16.04 the standard python version is still Python 2.7.15. We only have 1 year and 4 months left on the clock until version 2.7 has its end-of-life. (https://pythonclock.org/)

So I thought using Python 3.6.5 makes more sense for the Docker image since a lot of people will be using it that way.

If you are concerned with speed I could also change it to 3.7 which is even faster than 2.7 now.

I hope this helps :) 