### PR TITLE
Added string serialization of all xpath return types.

### DIFF
--- a/kibitzr/transformer/html.py
+++ b/kibitzr/transformer/html.py
@@ -95,6 +95,7 @@ def xpath_selector(selector, html, select_all):
         xpath_results = [xpath_results]
 
     # Serialize xpath_results
+    # see https://lxml.de/xpathxslt.html#xpath-return-values
     results = []
     for r in xpath_results:
         # namespace declarations

--- a/tests/unit/transforms/test_html.py
+++ b/tests/unit/transforms/test_html.py
@@ -50,6 +50,30 @@ def test_xpath_selector_all():
     ])
 
 
+def test_xpath_selector_boolean():
+    ok, content = run_transform('xpath', 'boolean(//body/h2/a)', HTML)
+    assert ok is True
+    assert content.strip() == 'True'
+
+
+def test_xpath_selector_float():
+    ok, content = run_transform('xpath', 'count(//div)', HTML)
+    assert ok is True
+    assert content.strip() == '2.0'
+
+
+def test_xpath_selector_attribute():
+    ok, content = run_transform('xpath', '//body/h2/a/@href', HTML)
+    assert ok is True
+    assert content.strip() == 'page.html'
+
+
+def test_xpath_selector_namespace():
+    ok, content = run_transform('xpath', '/html/namespace::*[name()]', HTML)
+    assert ok is True
+    assert content.strip() == 'xml="http://www.w3.org/XML/1998/namespace"'
+
+
 def test_extract_test():
     ok, content = run_transform('text', None, HTML)
     assert ok is True

--- a/tests/unit/transforms/test_html.py
+++ b/tests/unit/transforms/test_html.py
@@ -38,7 +38,7 @@ def test_css_selector_all():
 def test_xpath_selector():
     ok, content = run_transform('xpath', '//body/h2/a[@id="page-link"]', HTML)
     assert ok is True
-    assert content.strip() == '<a href="page.html" id="page-link">Page</a>'
+    assert content == '<a href="page.html" id="page-link">Page</a>'
 
 
 def test_xpath_selector_all():
@@ -53,25 +53,25 @@ def test_xpath_selector_all():
 def test_xpath_selector_boolean():
     ok, content = run_transform('xpath', 'boolean(//body/h2/a)', HTML)
     assert ok is True
-    assert content.strip() == 'True'
+    assert content == 'True'
 
 
 def test_xpath_selector_float():
     ok, content = run_transform('xpath', 'count(//div)', HTML)
     assert ok is True
-    assert content.strip() == '2.0'
+    assert content == '2.0'
 
 
 def test_xpath_selector_attribute():
     ok, content = run_transform('xpath', '//body/h2/a/@href', HTML)
     assert ok is True
-    assert content.strip() == 'page.html'
+    assert content == 'page.html'
 
 
 def test_xpath_selector_namespace():
     ok, content = run_transform('xpath', '/html/namespace::*[name()]', HTML)
     assert ok is True
-    assert content.strip() == 'xml="http://www.w3.org/XML/1998/namespace"'
+    assert content == 'xml="http://www.w3.org/XML/1998/namespace"'
 
 
 def test_extract_test():


### PR DESCRIPTION
The dlxml.tostring() function used to convert to string it can't handle all the possible return values of an XPath query. The possible return values are listed at https://lxml.de/xpathxslt.html#xpath-return-values.

This pull request implements the necessary logic to handle all such cases. I implemented all the cases just for completeness, the one that I actually found missing is when the XPath query matches an attribute. The current version of kibitzr doesn't handle this case.