### PR TITLE
Added configuration option 'verify_cert'

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -32,8 +32,9 @@ If no name is provided, it will be auto-generated.
 The name is used in notifications and internally as a check identifier.
 
 Check may have ``url``.
-If it is provided, it will be used to fetch data.
-Another option is ``script``, which is an arbitrary bash script.
+If it is provided, it will be used to fetch data. Optionally ``verify_cert`` can be set
+to ``False`` to skip verificaiton of the SSL certificate.
+Alternativelly data can be fetched by ``script``, which is an arbitrary bash script.
 
 Check will be executed every ``period`` seconds.
 

--- a/kibitzr/fetcher/simple.py
+++ b/kibitzr/fetcher/simple.py
@@ -31,12 +31,13 @@ class SessionFetcher(object):
         })
         self.url = conf['url']
         self.valid_http = set(conf.get('valid_http', [200]))
+        self.verify_cert = conf.get('verify_cert', True)
 
     def fetch(self):
         retries = 3
         for retry in range(retries):
             try:
-                response = self.session.get(self.url, timeout=(3.05, 27))
+                response = self.session.get(self.url, timeout=(3.05, 27), verify=self.verify_cert)
             except self.EXCEPTED as exc:
                 if retry < retries - 1:
                     self.sleep_on_exception(exc, retry)


### PR DESCRIPTION
Simple exposed ``verify``  option of ``requests.get`` to be able to skip certificate validation. This is usefull for sel signed certs or sites that don't properly distribute their certificate.

The new option is ``verify_cert`` wich default is ``True``.