### PR TITLE
Fix TypeError in jinja transform xpath

### DIFF
--- a/kibitzr/transformer/html.py
+++ b/kibitzr/transformer/html.py
@@ -5,9 +5,6 @@ import functools
 
 import six
 
-from .utils import bake_parametrized
-from .xpath import xpath_selector
-
 
 logger = logging.getLogger(__name__)
 
@@ -91,12 +88,10 @@ def bake_html(key):
 
 def register():
     """
-    Return dictionary of tranform factories
+    Return dictionary of transform factories
     """
     registry = {
         key: bake_html(key)
         for key in ('css', 'css-all', 'tag', 'text')
     }
-    registry['xpath'] = bake_parametrized(xpath_selector, select_all=False)
-    registry['xpath-all'] = bake_parametrized(xpath_selector, select_all=True)
     return registry

--- a/kibitzr/transformer/html.py
+++ b/kibitzr/transformer/html.py
@@ -6,6 +6,7 @@ import functools
 import six
 
 from .utils import bake_parametrized
+from .xpath import xpath_selector
 
 
 logger = logging.getLogger(__name__)
@@ -65,52 +66,6 @@ class SoupOps(object):
         'css': css_selector,
         'text': extract_text,
     }
-
-
-def xpath_selector(selector, html, select_all):
-    """
-    Returns Xpath match for `selector` within `html`.
-
-    :param selector: XPath string
-    :param html: Unicode content
-    :param select_all: True to get all matches
-    """
-    from defusedxml import lxml as dlxml
-    from lxml import etree
-    import re
-
-    # lxml requires argument to be bytes
-    # see https://github.com/kibitzr/kibitzr/issues/47
-    encoded = html.encode('utf-8')
-    root = dlxml.fromstring(encoded, parser=etree.HTMLParser())
-    xpath_results = root.xpath(selector)
-    if not xpath_results:
-        logger.warning('XPath selector not found: %r', selector)
-        return False, html
-
-    if isinstance(xpath_results, list):
-        if select_all is False:
-            xpath_results = xpath_results[0:1]
-    else:
-        xpath_results = [xpath_results]
-
-    # Serialize xpath_results
-    # see https://lxml.de/xpathxslt.html#xpath-return-values
-    results = []
-    for r in xpath_results:
-        # namespace declarations
-        if isinstance(r, tuple):
-            results.append("%s=\"%s\"" % (r[0], r[1]))
-        # an element
-        elif hasattr(r, 'tag'):
-            results.append(
-                re.sub(r'\s+', ' ',
-                       dlxml.tostring(r, method='html', encoding='unicode'))
-            )
-        else:
-            results.append(r)
-
-    return True, u"\n".join(six.text_type(x).strip() for x in results)
 
 
 @contextlib.contextmanager

--- a/kibitzr/transformer/jinja_transform.py
+++ b/kibitzr/transformer/jinja_transform.py
@@ -7,7 +7,7 @@ import six
 
 from kibitzr.stash import LazyStash
 from .html import deep_recursion, SoupOps
-
+from .xpath import parse_html, serialize_xpath_results
 
 logger = logging.getLogger(__name__)
 
@@ -125,38 +125,18 @@ class LazyHTML(object):
 
 class LazyXML(object):
     def __init__(self, content):
-        from lxml import etree
         self.xml = content
         self._root = None
-        self.etree = etree
 
     @property
     def root(self):
         if self._root is None:
-            self._root = self.etree.fromstring(
-                self.xml,
-                parser=self.etree.HTMLParser(),
-            )
+            self._root = parse_html(self.xml)
         return self._root
 
     def xpath(self, selector):
-        def to_string(element):
-            try:
-                return self.etree.tostring(
-                    element,
-                    method='html',
-                    pretty_print=True,
-                    encoding='unicode',
-                )
-            except TypeError:
-                return str(element)
-
         elements = self.root.xpath(selector)
-
-        if isinstance(elements, (list, tuple)):
-            return [to_string(element) for element in elements]
-        else:
-            return to_string(elements)
+        return serialize_xpath_results(elements, select_all=True)
 
 
 def register():

--- a/kibitzr/transformer/jinja_transform.py
+++ b/kibitzr/transformer/jinja_transform.py
@@ -140,16 +140,23 @@ class LazyXML(object):
         return self._root
 
     def xpath(self, selector):
+        def to_string(element):
+            try:
+                return self.etree.tostring(
+                    element,
+                    method='html',
+                    pretty_print=True,
+                    encoding='unicode',
+                )
+            except TypeError:
+                return str(element)
+
         elements = self.root.xpath(selector)
-        return [
-            self.etree.tostring(
-                element,
-                method='html',
-                pretty_print=True,
-                encoding='unicode',
-            )
-            for element in elements
-        ]
+
+        if isinstance(elements, (list, tuple)):
+            return [to_string(element) for element in elements]
+        else:
+            return to_string(elements)
 
 
 def register():

--- a/kibitzr/transformer/xpath.py
+++ b/kibitzr/transformer/xpath.py
@@ -1,0 +1,57 @@
+import logging
+
+import six
+
+logger = logging.getLogger(__name__)
+
+
+def parse_html(html):
+    from defusedxml import lxml as dlxml
+    from lxml import etree
+
+    # lxml requires argument to be bytes
+    # see https://github.com/kibitzr/kibitzr/issues/47
+    encoded = html.encode('utf-8')
+    return dlxml.fromstring(encoded, parser=etree.HTMLParser())
+
+
+def xpath_selector(selector, html, select_all):
+    """
+    Returns Xpath match for `selector` within `html`.
+
+    :param selector: XPath string
+    :param html: Unicode content
+    :param select_all: True to get all matches
+    """
+    from defusedxml import lxml as dlxml
+    import re
+
+    root = parse_html(html)
+    xpath_results = root.xpath(selector)
+    if not xpath_results:
+        logger.warning('XPath selector not found: %r', selector)
+        return False, html
+
+    if isinstance(xpath_results, list):
+        if select_all is False:
+            xpath_results = xpath_results[0:1]
+    else:
+        xpath_results = [xpath_results]
+
+    # Serialize xpath_results
+    # see https://lxml.de/xpathxslt.html#xpath-return-values
+    results = []
+    for r in xpath_results:
+        # namespace declarations
+        if isinstance(r, tuple):
+            results.append("%s=\"%s\"" % (r[0], r[1]))
+        # an element
+        elif hasattr(r, 'tag'):
+            results.append(
+                re.sub(r'\s+', ' ',
+                       dlxml.tostring(r, method='html', encoding='unicode'))
+            )
+        else:
+            results.append(r)
+
+    return True, u"\n".join(six.text_type(x).strip() for x in results)

--- a/kibitzr/transformer/xpath.py
+++ b/kibitzr/transformer/xpath.py
@@ -5,6 +5,8 @@ import six
 from defusedxml import lxml as dlxml
 from lxml import etree
 
+from .utils import bake_parametrized
+
 
 logger = logging.getLogger(__name__)
 
@@ -68,3 +70,14 @@ def xpath_selector(selector, html, select_all):
         logger.warning('XPath selector not found: %r', selector)
         return False, html
     return True, serialize_xpath_results(xpath_results, select_all)
+
+
+def register():
+    """
+    Return dictionary of transform factories
+    """
+    registry = {
+        'xpath': bake_parametrized(xpath_selector, select_all=False),
+        'xpath-all': bake_parametrized(xpath_selector, select_all=True)
+    }
+    return registry

--- a/kibitzr/transformer/xpath.py
+++ b/kibitzr/transformer/xpath.py
@@ -1,9 +1,6 @@
 import logging
-import re
 
 import six
-from defusedxml import lxml as dlxml
-from lxml import etree
 
 from .utils import bake_parametrized
 
@@ -17,6 +14,9 @@ def parse_html(html):
 
     :param html: Unicode content
     """
+    from defusedxml import lxml as dlxml
+    from lxml import etree
+
     # lxml requires argument to be bytes
     # see https://github.com/kibitzr/kibitzr/issues/47
     encoded = html.encode('utf-8')
@@ -32,6 +32,9 @@ def serialize_xpath_results(xpath_results, select_all):
 
     :param select_all: True to get all matches
     """
+    from defusedxml import lxml as dlxml
+    import re
+
     if isinstance(xpath_results, list):
         if select_all is False:
             xpath_results = xpath_results[0:1]

--- a/tests/unit/transforms/helpers.py
+++ b/tests/unit/transforms/helpers.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from kibitzr.transformer import transform_factory
+
+
+HTML = u"""<?xml version="1.0" encoding="utf-8"?>
+<html>
+    <body>
+        <h2 class="header nav">
+            <a href="page.html" id="page-link">Page</a>
+        </h2>
+        <div id="content">
+            Привет, Мир!
+        </div>
+        <div class="footer">
+            Footer content
+        </div>
+    </body>
+</html>
+"""
+
+
+def run_transform(key, value, content):
+    pipeline = transform_factory({'transform': [{key: value}]})
+    return pipeline(True, content)

--- a/tests/unit/transforms/test_html.py
+++ b/tests/unit/transforms/test_html.py
@@ -1,12 +1,7 @@
 # -*- coding: utf-8 -*-
 from bs4 import BeautifulSoup
 
-from kibitzr.transformer import transform_factory
-
-
-def run_transform(key, value, content):
-    pipeline = transform_factory({'transform': [{key: value}]})
-    return pipeline(True, content)
+from .helpers import run_transform, HTML
 
 
 def test_tag_selector():
@@ -35,45 +30,6 @@ def test_css_selector_all():
     ])
 
 
-def test_xpath_selector():
-    ok, content = run_transform('xpath', '//body/h2/a[@id="page-link"]', HTML)
-    assert ok is True
-    assert content == '<a href="page.html" id="page-link">Page</a>'
-
-
-def test_xpath_selector_all():
-    ok, content = run_transform('xpath-all', '//div', HTML)
-    assert ok is True
-    assert content == u'\n'.join([
-        u'<div id="content"> Привет, Мир! </div>',
-        u'<div class="footer"> Footer content </div>',
-    ])
-
-
-def test_xpath_selector_boolean():
-    ok, content = run_transform('xpath', 'boolean(//body/h2/a)', HTML)
-    assert ok is True
-    assert content == 'True'
-
-
-def test_xpath_selector_float():
-    ok, content = run_transform('xpath', 'count(//div)', HTML)
-    assert ok is True
-    assert content == '2.0'
-
-
-def test_xpath_selector_attribute():
-    ok, content = run_transform('xpath', '//body/h2/a/@href', HTML)
-    assert ok is True
-    assert content == 'page.html'
-
-
-def test_xpath_selector_namespace():
-    ok, content = run_transform('xpath', '/html/namespace::*[name()]', HTML)
-    assert ok is True
-    assert content == 'xml="http://www.w3.org/XML/1998/namespace"'
-
-
 def test_extract_test():
     ok, content = run_transform('text', None, HTML)
     assert ok is True
@@ -82,23 +38,6 @@ def test_extract_test():
         u"Привет, Мир!",
         u"Footer content",
     ])
-
-
-HTML = u"""<?xml version="1.0" encoding="utf-8"?>
-<html>
-    <body>
-        <h2 class="header nav">
-            <a href="page.html" id="page-link">Page</a>
-        </h2>
-        <div id="content">
-            Привет, Мир!
-        </div>
-        <div class="footer">
-            Footer content
-        </div>
-    </body>
-</html>
-"""
 
 
 def prettify(html):

--- a/tests/unit/transforms/test_jinja.py
+++ b/tests/unit/transforms/test_jinja.py
@@ -1,3 +1,4 @@
+import pytest
 from kibitzr.transformer.jinja_transform import JinjaTransform
 
 from ...helpers import stash_mock
@@ -34,13 +35,24 @@ def test_css_selector_is_passed():
     assert content == "P"
 
 
-def test_xpath_selector_is_passed():
+# For possible types of xpath evaluation:
+# https://lxml.de/xpathxslt.html#xpath-return-values
+@pytest.mark.parametrize("selector,expected", [
+    pytest.param("//div/p", "P", id="elements"),
+    pytest.param("//a/@href", "#", id="attributes"),
+    pytest.param("string(//p)", "P", id="string"),
+    pytest.param("count(//p)", "1.0", id="float"),
+    pytest.param("true()", "True", id="boolean"),
+    ])
+def test_xpath_selector_is_passed(selector, expected):
+    code = '{{ xpath("%s") | text }}' % selector
+
     ok, content = jinja_transform(
-        '{{ xpath("//div/p") | text }}',
-        '<div><a>A</a><p>P</p></div>',
-    )
+        code,
+        '<div><a href="#">A</a><p>P</p></div>'
+        )
     assert ok is True
-    assert content == "P"
+    assert content == expected
 
 
 def test_stash_is_passed():

--- a/tests/unit/transforms/test_jinja.py
+++ b/tests/unit/transforms/test_jinja.py
@@ -1,4 +1,3 @@
-import pytest
 from kibitzr.transformer.jinja_transform import JinjaTransform
 
 from ...helpers import stash_mock
@@ -35,24 +34,13 @@ def test_css_selector_is_passed():
     assert content == "P"
 
 
-# For possible types of xpath evaluation:
-# https://lxml.de/xpathxslt.html#xpath-return-values
-@pytest.mark.parametrize("selector,expected", [
-    pytest.param("//div/p", "P", id="elements"),
-    pytest.param("//a/@href", "#", id="attributes"),
-    pytest.param("string(//p)", "P", id="string"),
-    pytest.param("count(//p)", "1.0", id="float"),
-    pytest.param("true()", "True", id="boolean"),
-])
-def test_xpath_selector_is_passed(selector, expected):
-    code = '{{ xpath("%s") | text }}' % selector
-
+def test_xpath_selector_is_passed():
     ok, content = jinja_transform(
-        code,
-        '<div><a href="#">A</a><p>P</p></div>'
+        '{{ xpath("//div/p") | text }}',
+        '<div><a>A</a><p>P</p></div>',
     )
     assert ok is True
-    assert content == expected
+    assert content == "P"
 
 
 def test_stash_is_passed():

--- a/tests/unit/transforms/test_jinja.py
+++ b/tests/unit/transforms/test_jinja.py
@@ -43,14 +43,14 @@ def test_css_selector_is_passed():
     pytest.param("string(//p)", "P", id="string"),
     pytest.param("count(//p)", "1.0", id="float"),
     pytest.param("true()", "True", id="boolean"),
-    ])
+])
 def test_xpath_selector_is_passed(selector, expected):
     code = '{{ xpath("%s") | text }}' % selector
 
     ok, content = jinja_transform(
         code,
         '<div><a href="#">A</a><p>P</p></div>'
-        )
+    )
     assert ok is True
     assert content == expected
 

--- a/tests/unit/transforms/test_xpath.py
+++ b/tests/unit/transforms/test_xpath.py
@@ -1,11 +1,29 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from .helpers import run_transform, HTML
 
 
-def test_xpath_selector():
-    ok, content = run_transform('xpath', '//body/h2/a[@id="page-link"]', HTML)
+@pytest.mark.parametrize("selector,expected", [
+    pytest.param('boolean(//body/h2/a)', 'True', id='boolean'),
+    pytest.param("count(//div)", "2.0", id="float"),
+    pytest.param("string(//a)", "Page", id="string"),
+    pytest.param("//body/h2/a/@href", "page.html", id="attribute"),
+    pytest.param(
+        '//body/h2/a[@id="page-link"]',
+        '<a href="page.html" id="page-link">Page</a>',
+        id='element'
+    ),
+    pytest.param(
+        '/html/namespace::*[name()]',
+        'xml="http://www.w3.org/XML/1998/namespace"',
+        id='namespace'
+    ),
+])
+def test_xpath_selector(selector, expected):
+    ok, content = run_transform('xpath', selector, HTML)
     assert ok is True
-    assert content == '<a href="page.html" id="page-link">Page</a>'
+    assert content == expected
 
 
 def test_xpath_selector_all():
@@ -15,27 +33,3 @@ def test_xpath_selector_all():
         u'<div id="content"> Привет, Мир! </div>',
         u'<div class="footer"> Footer content </div>',
     ])
-
-
-def test_xpath_selector_boolean():
-    ok, content = run_transform('xpath', 'boolean(//body/h2/a)', HTML)
-    assert ok is True
-    assert content == 'True'
-
-
-def test_xpath_selector_float():
-    ok, content = run_transform('xpath', 'count(//div)', HTML)
-    assert ok is True
-    assert content == '2.0'
-
-
-def test_xpath_selector_attribute():
-    ok, content = run_transform('xpath', '//body/h2/a/@href', HTML)
-    assert ok is True
-    assert content == 'page.html'
-
-
-def test_xpath_selector_namespace():
-    ok, content = run_transform('xpath', '/html/namespace::*[name()]', HTML)
-    assert ok is True
-    assert content == 'xml="http://www.w3.org/XML/1998/namespace"'

--- a/tests/unit/transforms/test_xpath.py
+++ b/tests/unit/transforms/test_xpath.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from .helpers import run_transform, HTML
+
+
+def test_xpath_selector():
+    ok, content = run_transform('xpath', '//body/h2/a[@id="page-link"]', HTML)
+    assert ok is True
+    assert content == '<a href="page.html" id="page-link">Page</a>'
+
+
+def test_xpath_selector_all():
+    ok, content = run_transform('xpath-all', '//div', HTML)
+    assert ok is True
+    assert content == u'\n'.join([
+        u'<div id="content"> Привет, Мир! </div>',
+        u'<div class="footer"> Footer content </div>',
+    ])
+
+
+def test_xpath_selector_boolean():
+    ok, content = run_transform('xpath', 'boolean(//body/h2/a)', HTML)
+    assert ok is True
+    assert content == 'True'
+
+
+def test_xpath_selector_float():
+    ok, content = run_transform('xpath', 'count(//div)', HTML)
+    assert ok is True
+    assert content == '2.0'
+
+
+def test_xpath_selector_attribute():
+    ok, content = run_transform('xpath', '//body/h2/a/@href', HTML)
+    assert ok is True
+    assert content == 'page.html'
+
+
+def test_xpath_selector_namespace():
+    ok, content = run_transform('xpath', '/html/namespace::*[name()]', HTML)
+    assert ok is True
+    assert content == 'xml="http://www.w3.org/XML/1998/namespace"'


### PR DESCRIPTION
When an XPath expession evaluates to something other than a list of elements  jinja_transform.py raises a TypeError, like this: 
```
TypeError: Type 'lxml.etree._ElementUnicodeResult' cannot be serialized.
```
This change should fix it.
Tested with Python 3.7.3.