### PR TITLE
travis: Update geckodriver to v0.27.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     firefox: latest
 install:
   - >
-    curl -L https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz
+    curl -L https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz
     | tar zxf -
   - pip install -e . -r requirements/dev.txt coveralls
 env:


### PR DESCRIPTION
This PR updates geckodriver to v0.27.0 in CI.
