### PR TITLE
Fix release Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: peterdemin/kibitzr:latest,peterdemin/kibitzr:${{ steps.get_tag.outputs.TAG }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt -qqy update                     \
 COPY . /kibitzr/
 
 RUN cd /kibitzr                         \
+    && pip3 install --upgrade pip       \
     && pip3 install -e .
 
 WORKDIR /root/


### PR DESCRIPTION
@peterdemin This should fix the problems with cryptography.

I'm afraid the Gecko Driver isn't available for ARM (out of the box). There are [ways to handle this](https://firefox-source-docs.mozilla.org/testing/geckodriver/ARM.html), but this would require some time.