### PR TITLE
graceful shutdown (return 0) on interrupt

### DIFF
--- a/kibitzr/app.py
+++ b/kibitzr/app.py
@@ -59,7 +59,7 @@ class Application:
         try:
             while True:
                 if self.signals['interrupted']:
-                    return 1
+                    break
                 if self.signals['reload_conf_pending']:
                     settings().reread()
                     self.signals['reload_conf_pending'] = False

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -11,7 +11,7 @@ def test_main_executes_all_checks_before_loop(app, settings):
             'name': 'A',
             'script': {'python': 'ok, content = True, "ok"'}
         })
-        assert app.run() == 1
+        assert app.run() == 0
     assert the_loop.call_count == 1
     assert the_loop.call_args[0][0][0].check.call_count == 1
 
@@ -22,6 +22,6 @@ def test_main_filters_names(app, settings):
             {'name': 'A', 'url': 'A'},
             {'name': 'B', 'url': 'B'},
         ])
-        assert app.run(names=['B']) == 1
+        assert app.run(names=['B']) == 0
     assert the_loop.call_count == 1
     assert the_loop.call_args[0][0][0].check.call_count == 1

--- a/tests/unit/test_timeline.py
+++ b/tests/unit/test_timeline.py
@@ -12,7 +12,7 @@ def test_dummy_schedule(app, settings, check_noop):
         'script': {'python': 'ok, content = True, "ok"'},
         'schedule': [TimelineRule(interval=0, unit='seconds', at=None)],
     })
-    assert app.run() == 1
+    assert app.run() == 0
     assert check_noop.call_count == 2
 
 


### PR DESCRIPTION
This might just be my idiosyncrasy, but I expected that when the program was interrupted (e.g., `kill -s TERM pid`), it would gracefully shutdown and return a 0 exit code.

I am running kibitzr in a systemd service, and when I `ExecStop` the app using `kill -s TERM`, it was giving me a failure code, so I wanted to fix that.

I also think it is good for `cleanup_fetchers()` to run when interrupted instead of immediately returning 1


(I recognize you might not want to make/accept this change. I figured I'd put it out there in case you or others want it, though)