### PR TITLE
fix sending to ntfy with a large body

### DIFF
--- a/kibitzr/notifier/ntfy.py
+++ b/kibitzr/notifier/ntfy.py
@@ -22,24 +22,25 @@ class NtfyNotify:
         if 'topic' in value:
             self.topic = value.get('topic')
         self.title = value.get('title', 'kibitzr')
-        self.priority = value.get('priority', 3)
+        self.priority = str(value.get('priority', 3))
+
+        self.url = f'{self.url.rstrip("/")}/{self.topic}'
 
     def post(self, report):
         logger.info("Executing ntfy notifier")
         response = self.session.post(
             url=self.url,
-            json=self.json(report),
+            headers=self.headers(),
+            data=report,
         )
         logger.debug(response.text)
         response.raise_for_status()
     __call__ = post
 
-    def json(self, report):
+    def headers(self):
         return {
-            'topic': self.topic,
-            'title': self.title,
-            'message': report,
-            'priority': self.priority
+            'X-Title': self.title,
+            'X-Priority': self.priority
         }
 
 

--- a/tests/unit/notifiers/test_ntfy.py
+++ b/tests/unit/notifiers/test_ntfy.py
@@ -23,13 +23,9 @@ def test_ntfy_default(settings):
     with mock.patch.object(notify.session, 'post') as fake_post:
         notify('report')
     fake_post.assert_called_once_with(
-        url='http://localhost:8080',
-        json={
-            'topic': 'secret-topic',
-            'title': 'kibitzr',
-            'message': 'report',
-            'priority': 3
-        },
+        url='http://localhost:8080/secret-topic',
+        headers={'X-Title': 'kibitzr', 'X-Priority': '3'},
+        data='report',
     )
 
     assert 'Authorization' not in notify.session.headers
@@ -48,13 +44,9 @@ def test_ntfy_override_defaults(settings):
     with mock.patch.object(notify.session, 'post') as fake_post:
         notify('report')
     fake_post.assert_called_once_with(
-        url='http://localhost:8080',
-        json={
-            'topic': 'another-topic',
-            'title': 'Important Notification',
-            'message': 'report',
-            'priority': 5
-        },
+        url='http://localhost:8080/another-topic',
+        headers={'X-Title': 'Important Notification', 'X-Priority': '5'},
+        data='report',
     )
 
     assert 'Authorization' in notify.session.headers


### PR DESCRIPTION
Previously, we were sending messages to ntfy using a JSON payload. However, a large JSON body will be rejected by ntfy.

This changes kibitzr to instead send the `report` to ntfy in the POST body itself with additional parameters (e.g., `title`, `priority`) sent as HTTP headers. Larger messages can be sent to ntfy this way